### PR TITLE
Fixed 'grc' conflict; 'Rebase' in git/alias.sh

### DIFF
--- a/modules/git/alias.zsh
+++ b/modules/git/alias.zsh
@@ -125,11 +125,11 @@ alias gpc='git push --set-upstream origin "$(git-branch-current 2> /dev/null)"'
 alias gpp='git pull origin "$(git-branch-current 2> /dev/null)" && git push origin "$(git-branch-current 2> /dev/null)"'
 
 # Rebase (r)
-alias gr='git rebase'
-alias gra='git rebase --abort'
-alias grc='git rebase --continue'
-alias gri='git rebase --interactive'
-alias grs='git rebase --skip'
+alias grb='git rebase'
+alias grba='git rebase --abort'
+alias grbc='git rebase --continue'
+alias grbi='git rebase --interactive'
+alias grbs='git rebase --skip'
 
 # Remote (R)
 alias gR='git remote'


### PR DESCRIPTION
I changed the Git-Rebase aliases to resolve a conflict with `grc` command. Git-Rebase `gr...` alias is now `grb...`, and more specifically; the offending `grc` alias is now `grbc`.

I found this to be necessary as Zsh was depending on `grc` command and throwing an error about the conflict. I don't want Prezto to conflict with Zsh when using `grc`, so I changed the alias to the closest semantic equivalent.